### PR TITLE
Removed navbar menu button focus mode

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -115,6 +115,10 @@ hr {
     border-color: transparent !important;
 }
 
+.navbar-toggler:focus {
+    outline: none;
+}
+
 @keyframes nav-rot-on {
     from {
         transform: rotate(0deg);


### PR DESCRIPTION
I think this will stop it from showing an outline after being clicked/pressed in mobile format