### PR TITLE
Made navbar dropdown links take up (almost) the full width of the page

### DIFF
--- a/assets/js/navbar-button.js
+++ b/assets/js/navbar-button.js
@@ -1,4 +1,9 @@
 let navBtn = document.getElementsByClassName("navbar-toggler")[0];
+let dropdownLinks = document.getElementsByClassName("nav-link");
+let ddLinkWidths = [];
+for (let i = 0; i < dropdownLinks.length; i++) {
+    ddLinkWidths.push(dropdownLinks[i].style.width);
+}
 
 let toggledOn = false;
 
@@ -6,8 +11,14 @@ navBtn.addEventListener("click", function handleClick() {
     if (!toggledOn) {
         toggledOn = true;
         navBtn.style.animation = "nav-rot-on 0.3s ease-in-out forwards";
+        for (let i = 0; i < dropdownLinks.length; i++) {
+            dropdownLinks[i].style.width = "100%";
+        }
     } else {
         toggledOn = false;
         navBtn.style.animation = "nav-rot-off 0.3s ease-in-out forwards";
+        for (let i = 0; i < dropdownLinks.length; i++) {
+            dropdownLinks[i].style.width = ddLinkWidths[i];
+        }
     }
 });


### PR DESCRIPTION
QoL feature that I wanted - this means that in mobile format, you don't have to click/press the word itself in the navbar dropdown menu, you can just click/press anywhere horizontal of it.

Reverts to original width when the dropdown menu is closed to help maintain on-the-fly navbar responsiveness.